### PR TITLE
Fixed display bug for flipping flashcards

### DIFF
--- a/src/main/java/com/unibuc/mds/memoreasy/Controllers/ChapterController.java
+++ b/src/main/java/com/unibuc/mds/memoreasy/Controllers/ChapterController.java
@@ -59,7 +59,7 @@ public class ChapterController {
 
             while (rs.next()) {
                 // Adaugă fiecare flashcard în listă
-                flashcards.add(new Flashcard(rs.getInt(1), rs.getString(2), rs.getString(3)));
+                flashcards.add(new Flashcard(rs.getInt(1), rs.getString(3), rs.getString(5)));
             }
             con.close();
 


### PR DESCRIPTION
The flip content was wrong.

Edited the id's for the displayed content to match the database table columns.